### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,7 +72,7 @@ class jenkins(
     if ! defined(Package['fontconfig'])       { package { 'fontconfig':       ensure => installed } }
     if ! defined(Package['fontconfig-devel']) { package { 'fontconfig-devel': ensure => installed } }
 
-    if $::operatingsystem == 'CentOS' and $::operatingsystemrelease >= 6 {
+    if $::operatingsystem == 'CentOS' {
       package { [ "dejavu-sans-fonts", "dejavu-sans-mono-fonts", "dejavu-serif-fonts"]: 
         ensure => installed,
       }


### PR DESCRIPTION
This was raising a failed string comparison error. Additionally we don't care about centos 6 any more.